### PR TITLE
login: set auth cookie default SameSite config to Lax

### DIFF
--- a/login/builder.go
+++ b/login/builder.go
@@ -172,7 +172,7 @@ func New() *Builder {
 			Path:     "/",
 			Domain:   "",
 			Secure:   true,
-			SameSite: http.SameSiteStrictMode,
+			SameSite: http.SameSiteLaxMode,
 		},
 		autoExtendSession: true,
 		maxRetryCount:     5,


### PR DESCRIPTION
allow users to stay logged in when navigating to a qor site from a third-party link by default.