### PR TITLE
Potential fix for code scanning alert no. 36: Reflected cross-site scripting

### DIFF
--- a/login/builder.go
+++ b/login/builder.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pquerna/otp/totp"
 	"github.com/qor5/web/v3"
 	h "github.com/theplant/htmlgo"
+	"html"
 	"golang.org/x/text/language"
 	"gorm.io/gorm"
 
@@ -695,13 +696,14 @@ func (b *Builder) completeUserAuthCallback(w http.ResponseWriter, r *http.Reques
 	}
 
 	completeURL := fmt.Sprintf("%s?%s", b.oauthCallbackCompleteURL, r.URL.Query().Encode())
+	escapedCompleteURL := html.EscapeString(completeURL)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write([]byte(fmt.Sprintf(`
 <script>
 window.location.href=%q;
 </script>
 <a href=%q>complete</a>
-    `, completeURL, completeURL)))
+    `, escapedCompleteURL, escapedCompleteURL)))
 }
 
 func (b *Builder) completeUserAuthCallbackComplete(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Potential fix for [https://github.com/qor5/x/security/code-scanning/36](https://github.com/qor5/x/security/code-scanning/36)

To fix the reflected cross-site scripting vulnerability, we need to ensure that any user-provided data included in the HTML response is properly escaped. In this case, we should use the `html.EscapeString` function from the `html` package to escape the `completeURL` before including it in the HTML response. This will prevent any malicious scripts from being executed in the user's browser.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
