### PR TITLE
fix: update vuetify-pro-tiptap dependency URL in package.json

### DIFF
--- a/ui/vuetifyx/vuetifyxjs/package.json
+++ b/ui/vuetifyx/vuetifyxjs/package.json
@@ -30,7 +30,7 @@
     "vue-json-pretty": "^2.4.0",
     "vuedraggable": "^4.1.0",
     "vuetify": "^3.7.18",
-    "vuetify-pro-tiptap": "github:qor5/vuetify-pro-tiptap"
+    "vuetify-pro-tiptap": "https://github.com/qor5/vuetify-pro-tiptap.git"
   },
   "devDependencies": {
     "@babel/types": "^7.26.10",

--- a/ui/vuetifyx/vuetifyxjs/pnpm-lock.yaml
+++ b/ui/vuetifyx/vuetifyxjs/pnpm-lock.yaml
@@ -59,8 +59,8 @@ importers:
         specifier: ^3.7.18
         version: 3.7.18(typescript@5.8.2)(vite-plugin-vuetify@2.1.0)(vue@3.5.13(typescript@5.8.2))
       vuetify-pro-tiptap:
-        specifier: github:qor5/vuetify-pro-tiptap
-        version: git+https://git@github.com:qor5/vuetify-pro-tiptap.git#6617b0836ffa984aeee381494ba43fc132609c25(@tiptap/suggestion@2.12.0(@tiptap/core@2.11.5(@tiptap/pm@2.11.5))(@tiptap/pm@2.11.5))(vue@3.5.13(typescript@5.8.2))(vuetify@3.7.18)
+        specifier: https://github.com/qor5/vuetify-pro-tiptap.git
+        version: https://codeload.github.com/qor5/vuetify-pro-tiptap/tar.gz/6617b0836ffa984aeee381494ba43fc132609c25(@tiptap/suggestion@2.12.0(@tiptap/core@2.11.5(@tiptap/pm@2.11.5))(@tiptap/pm@2.11.5))(vue@3.5.13(typescript@5.8.2))(vuetify@3.7.18)
     devDependencies:
       '@babel/types':
         specifier: ^7.26.10
@@ -3033,8 +3033,8 @@ packages:
     peerDependencies:
       vue: ^3.0.1
 
-  vuetify-pro-tiptap@git+https://git@github.com:qor5/vuetify-pro-tiptap.git#6617b0836ffa984aeee381494ba43fc132609c25:
-    resolution: {commit: 6617b0836ffa984aeee381494ba43fc132609c25, repo: git@github.com:qor5/vuetify-pro-tiptap.git, type: git}
+  vuetify-pro-tiptap@https://codeload.github.com/qor5/vuetify-pro-tiptap/tar.gz/6617b0836ffa984aeee381494ba43fc132609c25:
+    resolution: {tarball: https://codeload.github.com/qor5/vuetify-pro-tiptap/tar.gz/6617b0836ffa984aeee381494ba43fc132609c25}
     version: 2.5.7
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     peerDependencies:
@@ -6309,7 +6309,7 @@ snapshots:
       sortablejs: 1.14.0
       vue: 3.5.13(typescript@5.8.2)
 
-  vuetify-pro-tiptap@git+https://git@github.com:qor5/vuetify-pro-tiptap.git#6617b0836ffa984aeee381494ba43fc132609c25(@tiptap/suggestion@2.12.0(@tiptap/core@2.11.5(@tiptap/pm@2.11.5))(@tiptap/pm@2.11.5))(vue@3.5.13(typescript@5.8.2))(vuetify@3.7.18):
+  vuetify-pro-tiptap@https://codeload.github.com/qor5/vuetify-pro-tiptap/tar.gz/6617b0836ffa984aeee381494ba43fc132609c25(@tiptap/suggestion@2.12.0(@tiptap/core@2.11.5(@tiptap/pm@2.11.5))(@tiptap/pm@2.11.5))(vue@3.5.13(typescript@5.8.2))(vuetify@3.7.18):
     dependencies:
       '@tiptap/core': 2.11.5(@tiptap/pm@2.11.5)
       '@tiptap/extension-blockquote': 2.12.0(@tiptap/core@2.11.5(@tiptap/pm@2.11.5))


### PR DESCRIPTION
- Changed the dependency URL for vuetify-pro-tiptap from a shorthand GitHub reference to a full HTTPS link for improved clarity and reliability.