### PR TITLE
fix: improve datetime parsing in FilterData based on ItemType

### DIFF
--- a/ui/vuetifyx/filter.go
+++ b/ui/vuetifyx/filter.go
@@ -329,9 +329,15 @@ func (fd FilterData) SetByQueryString(ctx *web.EventContext, qs string) (sqlCond
 		} else {
 			sqlc := fd.getSQLCondition(key, v[0])
 			if len(sqlc) > 0 {
-				if it.ItemType == ItemTypeDatetimeRange || it.ItemType == ItemTypeDatetimeRangePicker {
+				if it.ItemType == ItemTypeDatetimeRange {
 					var err error
 					val, err = time.ParseInLocation("2006-01-02 15:04", val.(string), time.Local)
+					if err != nil {
+						continue
+					}
+				} else if it.ItemType == ItemTypeDatetimeRangePicker {
+					var err error
+					val, err = time.ParseInLocation("2006-01-02 15:04:05", val.(string), time.Local)
 					if err != nil {
 						continue
 					}


### PR DESCRIPTION
- Enhanced the SetByQueryString method to handle datetime parsing for ItemTypeDatetimeRangePicker.
- Added specific parsing logic for both ItemTypeDatetimeRange and ItemTypeDatetimeRangePicker to accommodate different datetime formats.