### PR TITLE
Handle context cancellation race in transaction helpers

### DIFF
--- a/gormx/tx.go
+++ b/gormx/tx.go
@@ -8,15 +8,19 @@ import (
 	"gorm.io/gorm"
 )
 
-func Transaction(ctx context.Context, db *gorm.DB, fc func(tx *gorm.DB) error, opts ...*sql.TxOptions) error {
-	err := db.WithContext(ctx).Transaction(fc, opts...)
+func Transaction(db *gorm.DB, fc func(tx *gorm.DB) error, opts ...*sql.TxOptions) error {
+	var ctx context.Context
+	if db.Statement != nil {
+		ctx = db.Statement.Context
+	}
+	err := db.Transaction(fc, opts...)
 	if err != nil {
 		// Handle context cancellation race condition:
 		// When ctx is cancelled, database/sql's internal awaitDone goroutine may rollback
 		// the transaction before Commit() is called, resulting in ErrTxDone.
 		// In this case, return the context error instead of ErrTxDone to reflect the true cause.
 		// See: https://github.com/golang/go/issues/43507
-		if errors.Is(err, sql.ErrTxDone) && ctx.Err() != nil {
+		if ctx != nil && errors.Is(err, sql.ErrTxDone) && ctx.Err() != nil {
 			return errors.Wrap(ctx.Err(), "transaction failed")
 		}
 	}

--- a/gormx/tx.go
+++ b/gormx/tx.go
@@ -1,0 +1,24 @@
+package gormx
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pkg/errors"
+	"gorm.io/gorm"
+)
+
+func Transaction(ctx context.Context, db *gorm.DB, fc func(tx *gorm.DB) error, opts ...*sql.TxOptions) error {
+	err := db.WithContext(ctx).Transaction(fc, opts...)
+	if err != nil {
+		// Handle context cancellation race condition:
+		// When ctx is cancelled, database/sql's internal awaitDone goroutine may rollback
+		// the transaction before Commit() is called, resulting in ErrTxDone.
+		// In this case, return the context error instead of ErrTxDone to reflect the true cause.
+		// See: https://github.com/golang/go/issues/43507
+		if errors.Is(err, sql.ErrTxDone) && ctx.Err() != nil {
+			return errors.Wrap(ctx.Err(), "transaction failed")
+		}
+	}
+	return err
+}

--- a/gormx/tx_test.go
+++ b/gormx/tx_test.go
@@ -27,7 +27,7 @@ func TestTransaction_ContextCancellation(t *testing.T) {
 
 	cancelCtx, cancel := context.WithCancel(ctx)
 
-	err = gormx.Transaction(cancelCtx, db, func(tx *gorm.DB) error {
+	err = gormx.Transaction(db.WithContext(cancelCtx), func(tx *gorm.DB) error {
 		err := tx.Create(&TxTestUser{ID: "1", Name: "CancelUser", Balance: 100}).Error
 		if err != nil {
 			return err

--- a/gormx/tx_test.go
+++ b/gormx/tx_test.go
@@ -1,0 +1,49 @@
+package gormx_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/qor5/x/v3/gormx"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+type TxTestUser struct {
+	ID      string `gorm:"primaryKey"`
+	Name    string
+	Balance int
+}
+
+func TestTransaction_ContextCancellation(t *testing.T) {
+	ctx := context.Background()
+	db := suite.DB()
+
+	err := suite.ResetDB(ctx, &TxTestUser{})
+	assert.NoError(t, err)
+
+	cancelCtx, cancel := context.WithCancel(ctx)
+
+	err = gormx.Transaction(cancelCtx, db, func(tx *gorm.DB) error {
+		err := tx.Create(&TxTestUser{ID: "1", Name: "CancelUser", Balance: 100}).Error
+		if err != nil {
+			return err
+		}
+
+		// Cancel context and wait for awaitDone goroutine to rollback the transaction.
+		// This simulates the race condition where context cancellation triggers
+		// internal rollback before Commit() is called.
+		// See: https://github.com/golang/go/issues/43507
+		cancel()
+		time.Sleep(50 * time.Millisecond)
+		return nil
+	})
+
+	// Should return context.Canceled instead of sql.ErrTxDone
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled), "expected context.Canceled, got: %v", err)
+	assert.True(t, strings.Contains(err.Error(), "transaction failed"), "expected 'transaction failed' in error, got: %v", err)
+}


### PR DESCRIPTION
Add logic to gormx and sqlx transaction helpers to return the context error instead of sql.ErrTxDone when context cancellation causes a transaction rollback before commit. Includes new tests for context cancellation scenarios to ensure correct error propagation.