### PR TITLE
feat(statusx): add RATE_LIMITED error reason

### DIFF
--- a/ratelimiterx/grpc_test.go
+++ b/ratelimiterx/grpc_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/qor5/x/v3/gormx"
 	"github.com/qor5/x/v3/healthz/testdata/gen"
 	"github.com/qor5/x/v3/normalize"
+	statusv1 "github.com/qor5/x/v3/statusx/gen/status/v1"
 )
 
 // Test gRPC service implementation using healthz testdata
@@ -310,7 +311,8 @@ func TestUnaryServerInterceptor_ErrorMetadata(t *testing.T) {
 		require.NotEmpty(t, errorInfo.Metadata, "ErrorInfo should contain metadata")
 
 		// Verify the custom reason is set correctly
-		assert.Equal(t, "RATE_LIMITED", errorInfo.Reason, "Error reason should be RATE_LIMITED")
+		assert.Equal(t, statusv1.ErrorReason_RATE_LIMITED.String(), errorInfo.Reason, "Error reason should be RATE_LIMITED")
+		assert.Equal(t, "RATE_LIMITED", errorInfo.Reason, "Error reason wire value should remain RATE_LIMITED")
 
 		// Verify metadata contains required fields
 		metadata := errorInfo.Metadata

--- a/ratelimiterx/ratelimit.go
+++ b/ratelimiterx/ratelimit.go
@@ -12,8 +12,6 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-var ErrorReasonRateLimited = "RATE_LIMITED"
-
 type Evaluator func(ctx context.Context, callMeta *normalize.CallMeta) ([]*ratelimiter.ReserveRequest, error)
 
 type Metadata struct {
@@ -51,7 +49,7 @@ func allow(ctx context.Context, limiter ratelimiter.RateLimiter, evaluator Evalu
 			if err := jsonx.Copy(&md, &meta); err != nil {
 				return statusx.Wrap(err, codes.Internal, statusv1.ErrorReason_INTERNAL.String(), "failed to copy metadata").Err()
 			}
-			return statusx.New(codes.ResourceExhausted, ErrorReasonRateLimited, "ratelimit exceeded").
+			return statusx.New(codes.ResourceExhausted, statusv1.ErrorReason_RATE_LIMITED.String(), "ratelimit exceeded").
 				WithMetadata(md).
 				Err()
 		}

--- a/statusx/code_test.go
+++ b/statusx/code_test.go
@@ -41,3 +41,16 @@ func TestReasonFromCode(t *testing.T) {
 		})
 	}
 }
+
+func TestRateLimitedReason(t *testing.T) {
+	// RATE_LIMITED is a domain-specific reason, not aligned to a gRPC code.
+	// It lives at 100, leaving 17-99 reserved for future gRPC-code-aligned reasons.
+	assert.Equal(t, statusv1.ErrorReason(100), statusv1.ErrorReason_RATE_LIMITED)
+	assert.Equal(t, "RATE_LIMITED", statusv1.ErrorReason_RATE_LIMITED.String())
+
+	// It must not collide with any reason derived from a standard gRPC code.
+	for c := codes.OK; c <= codes.Unauthenticated; c++ {
+		assert.NotEqual(t, statusv1.ErrorReason_RATE_LIMITED, ReasonFromCode(c),
+			"RATE_LIMITED must not collide with the reason for code %s", c)
+	}
+}

--- a/statusx/code_test.go
+++ b/statusx/code_test.go
@@ -38,12 +38,19 @@ func TestReasonFromCode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := ReasonFromCode(tc.code)
 			assert.Equal(t, tc.expected, result)
-			// RATE_LIMITED is a domain-specific reason (value 100, with 17-99
-			// reserved for future gRPC-code-aligned reasons); no gRPC code maps to it.
-			assert.NotEqual(t, statusv1.ErrorReason_RATE_LIMITED, result)
 		})
 	}
+}
 
+func TestRateLimitedReason(t *testing.T) {
+	// RATE_LIMITED is a domain-specific reason, not aligned to a gRPC code.
+	// It lives at 100, leaving 17-99 reserved for future gRPC-code-aligned reasons.
 	assert.Equal(t, statusv1.ErrorReason(100), statusv1.ErrorReason_RATE_LIMITED)
 	assert.Equal(t, "RATE_LIMITED", statusv1.ErrorReason_RATE_LIMITED.String())
+
+	// It must not collide with any reason derived from a standard gRPC code.
+	for c := codes.OK; c <= codes.Unauthenticated; c++ {
+		assert.NotEqual(t, statusv1.ErrorReason_RATE_LIMITED, ReasonFromCode(c),
+			"RATE_LIMITED must not collide with the reason for code %s", c)
+	}
 }

--- a/statusx/code_test.go
+++ b/statusx/code_test.go
@@ -38,19 +38,12 @@ func TestReasonFromCode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := ReasonFromCode(tc.code)
 			assert.Equal(t, tc.expected, result)
+			// RATE_LIMITED is a domain-specific reason (value 100, with 17-99
+			// reserved for future gRPC-code-aligned reasons); no gRPC code maps to it.
+			assert.NotEqual(t, statusv1.ErrorReason_RATE_LIMITED, result)
 		})
 	}
-}
 
-func TestRateLimitedReason(t *testing.T) {
-	// RATE_LIMITED is a domain-specific reason, not aligned to a gRPC code.
-	// It lives at 100, leaving 17-99 reserved for future gRPC-code-aligned reasons.
 	assert.Equal(t, statusv1.ErrorReason(100), statusv1.ErrorReason_RATE_LIMITED)
 	assert.Equal(t, "RATE_LIMITED", statusv1.ErrorReason_RATE_LIMITED.String())
-
-	// It must not collide with any reason derived from a standard gRPC code.
-	for c := codes.OK; c <= codes.Unauthenticated; c++ {
-		assert.NotEqual(t, statusv1.ErrorReason_RATE_LIMITED, ReasonFromCode(c),
-			"RATE_LIMITED must not collide with the reason for code %s", c)
-	}
 }

--- a/statusx/gen/status/v1/error.pb.go
+++ b/statusx/gen/status/v1/error.pb.go
@@ -41,28 +41,31 @@ const (
 	ErrorReason_UNAVAILABLE         ErrorReason = 14
 	ErrorReason_DATA_LOSS           ErrorReason = 15
 	ErrorReason_UNAUTHENTICATED     ErrorReason = 16
+	// It's not a standard gRPC code, but we'll still put it here to handle other error codes in x.
+	ErrorReason_RATE_LIMITED ErrorReason = 100
 )
 
 // Enum value maps for ErrorReason.
 var (
 	ErrorReason_name = map[int32]string{
-		0:  "OK",
-		1:  "CANCELED",
-		2:  "UNKNOWN",
-		3:  "INVALID_ARGUMENT",
-		4:  "DEADLINE_EXCEEDED",
-		5:  "NOT_FOUND",
-		6:  "ALREADY_EXISTS",
-		7:  "PERMISSION_DENIED",
-		8:  "RESOURCE_EXHAUSTED",
-		9:  "FAILED_PRECONDITION",
-		10: "ABORTED",
-		11: "OUT_OF_RANGE",
-		12: "UNIMPLEMENTED",
-		13: "INTERNAL",
-		14: "UNAVAILABLE",
-		15: "DATA_LOSS",
-		16: "UNAUTHENTICATED",
+		0:   "OK",
+		1:   "CANCELED",
+		2:   "UNKNOWN",
+		3:   "INVALID_ARGUMENT",
+		4:   "DEADLINE_EXCEEDED",
+		5:   "NOT_FOUND",
+		6:   "ALREADY_EXISTS",
+		7:   "PERMISSION_DENIED",
+		8:   "RESOURCE_EXHAUSTED",
+		9:   "FAILED_PRECONDITION",
+		10:  "ABORTED",
+		11:  "OUT_OF_RANGE",
+		12:  "UNIMPLEMENTED",
+		13:  "INTERNAL",
+		14:  "UNAVAILABLE",
+		15:  "DATA_LOSS",
+		16:  "UNAUTHENTICATED",
+		100: "RATE_LIMITED",
 	}
 	ErrorReason_value = map[string]int32{
 		"OK":                  0,
@@ -82,6 +85,7 @@ var (
 		"UNAVAILABLE":         14,
 		"DATA_LOSS":           15,
 		"UNAUTHENTICATED":     16,
+		"RATE_LIMITED":        100,
 	}
 )
 
@@ -116,7 +120,7 @@ var File_status_v1_error_proto protoreflect.FileDescriptor
 
 const file_status_v1_error_proto_rawDesc = "" +
 	"\n" +
-	"\x15status/v1/error.proto\x12\tstatus.v1*\xbd\x02\n" +
+	"\x15status/v1/error.proto\x12\tstatus.v1*\xcf\x02\n" +
 	"\vErrorReason\x12\x06\n" +
 	"\x02OK\x10\x00\x12\f\n" +
 	"\bCANCELED\x10\x01\x12\v\n" +
@@ -135,7 +139,8 @@ const file_status_v1_error_proto_rawDesc = "" +
 	"\bINTERNAL\x10\r\x12\x0f\n" +
 	"\vUNAVAILABLE\x10\x0e\x12\r\n" +
 	"\tDATA_LOSS\x10\x0f\x12\x13\n" +
-	"\x0fUNAUTHENTICATED\x10\x10B\x95\x01\n" +
+	"\x0fUNAUTHENTICATED\x10\x10\x12\x10\n" +
+	"\fRATE_LIMITED\x10dB\x95\x01\n" +
 	"\rcom.status.v1B\n" +
 	"ErrorProtoP\x01Z3github.com/qor5/x/v3/statusx/gen/status/v1;statusv1\xa2\x02\x03SXX\xaa\x02\tStatus.V1\xca\x02\tStatus\\V1\xe2\x02\x15Status\\V1\\GPBMetadata\xea\x02\n" +
 	"Status::V1b\x06proto3"

--- a/statusx/proto/status/v1/error.proto
+++ b/statusx/proto/status/v1/error.proto
@@ -20,4 +20,7 @@ enum ErrorReason {
   UNAVAILABLE = 14;
   DATA_LOSS = 15;
   UNAUTHENTICATED = 16;
+
+  // It's not a standard gRPC code, but we'll still put it here to handle other error codes in x.
+  RATE_LIMITED = 100;
 }


### PR DESCRIPTION
## What

- Add `RATE_LIMITED = 100` to the `ErrorReason` enum in `statusx/proto/status/v1/error.proto`.
- Non-gRPC-code reasons start at 100, leaving values below reserved for future gRPC-code-aligned reasons.
- Regenerate `statusx/gen/status/v1/error.pb.go` via `buf generate`.
- Update `ratelimiterx` to use `statusv1.ErrorReason_RATE_LIMITED.String()` instead of the local `var ErrorReasonRateLimited = "RATE_LIMITED"` string literal.

## Why

The rate-limit reason was hardcoded as a string in `ratelimiterx`. Defining it in the shared `statusx` enum keeps all error reasons in one authoritative place and makes the value type-safe and reusable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)