### PR TITLE
feat(statusx): expose error metadata via x-status-metadata response header

### DIFF
--- a/statusx/vproto.go
+++ b/statusx/vproto.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -24,6 +25,16 @@ const HeaderEnsureConnectError = "x-ensure-connect-error"
 
 var AllowHeaders = []string{
 	http.CanonicalHeaderKey(HeaderEnsureConnectError),
+}
+
+// HeaderStatusMetadata carries the error's metadata (from statusx.WithMetadata)
+// on the HTTP response. Since vproto.ValidationError has no metadata field, the
+// metadata is exposed out-of-band: a JSON-encoded map[string]string, URL-escaped,
+// set on this header. It is only present when the error actually carries metadata.
+const HeaderStatusMetadata = "x-status-metadata"
+
+var ExposedHeaders = []string{
+	http.CanonicalHeaderKey(HeaderStatusMetadata),
 }
 
 func EnsureConnectError(ctx context.Context) bool {
@@ -115,6 +126,12 @@ func WriteVProtoHTTPError(err error, w http.ResponseWriter, r *http.Request) (xe
 				DefaultViewMsg: cmp.Or(fv.GetLocalizedMessage().GetMessage(), fv.GetDescription()),
 			})
 		}
+	}
+
+	// vproto.ValidationError has no metadata field, so expose the error's
+	// metadata (from statusx.WithMetadata) out-of-band on a response header.
+	if md := errorInfo.GetMetadata(); len(md) > 0 {
+		w.Header().Set(HeaderStatusMetadata, url.QueryEscape(jsonx.MustMarshalX[string](md)))
 	}
 
 	isJSON := isMimeTypeJSON(w.Header().Get(httpx.HeaderContentType))

--- a/statusx/vproto_test.go
+++ b/statusx/vproto_test.go
@@ -3,9 +3,11 @@ package statusx
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/qor5/x/v3/jsonx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -23,6 +25,53 @@ func TestWriteVProtoHTTPError_JSON(t *testing.T) {
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 
 	assert.Contains(t, w.Body.String(), "INVALID_ARGUMENT")
+}
+
+func TestWriteVProtoHTTPError_MetadataHeader(t *testing.T) {
+	md := map[string]string{"order_id": "123", "retry_after": "30s"}
+	tests := []struct {
+		name         string
+		err          error
+		wantMetadata map[string]string // nil means no metadata header expected
+	}{
+		{
+			name:         "with metadata sets header",
+			err:          New(codes.InvalidArgument, "INVALID_ARGUMENT", "invalid").WithMetadata(md).Err(),
+			wantMetadata: md,
+		},
+		{
+			name:         "without metadata omits header",
+			err:          BadRequest(NewFieldViolation("email", "REQUIRED", "Email is required")).Err(),
+			wantMetadata: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test", strings.NewReader("req"))
+			req.Header.Set("Accept", "application/json")
+			w := httptest.NewRecorder()
+
+			werr := WriteVProtoHTTPError(tt.err, w, req)
+			require.NoError(t, werr)
+
+			encoded := w.Header().Get(HeaderStatusMetadata)
+			if tt.wantMetadata == nil {
+				assert.Empty(t, encoded)
+				return
+			}
+
+			require.NotEmpty(t, encoded)
+
+			// Reverse the encoding done by WriteVProtoHTTPError: URL-unescape
+			// then JSON-unmarshal the header value back into a metadata map.
+			data, derr := url.QueryUnescape(encoded)
+			require.NoError(t, derr)
+			var decoded map[string]string
+			require.NoError(t, jsonx.Unmarshal([]byte(data), &decoded))
+			assert.Equal(t, tt.wantMetadata, decoded)
+		})
+	}
 }
 
 func TestWriteVProtoHTTPError_MarshalFailureFallbackJSON(t *testing.T) {


### PR DESCRIPTION
## What

On the vproto HTTP error path, error metadata set via `statusx.WithMetadata` was being dropped, because `vproto.ValidationError` has no metadata field. This exposes it out-of-band on a response header.

- Set `x-status-metadata` (JSON-encoded, URL-escaped `map[string]string`) on the response, only when the error actually carries metadata.
- Add `var ExposedHeaders` (symmetric to the existing `var AllowHeaders`) so downstreams using the vproto path can concat it into their CORS `ExposedHeaders`.

## Why this lives in statusx, not httpx

The connect protocol path already carries metadata natively in the error details (see `ConvertToConnectError`), so it needs no header. **Only the vproto path** needs this workaround, because its message schema lacks the field.

That means it would be wrong to wire the header into `httpx.Security` (the generic CORS middleware) — a service that doesn't use vproto would get an `x-status-metadata` header exposed that it never sets. The header is part of statusx's error protocol, so its ownership and its `ExposedHeaders` declaration stay in statusx. `httpx` is left untouched. Downstreams that use the vproto path opt in by adding `statusx.ExposedHeaders` to their CORS config.

## Test

- `TestWriteVProtoHTTPError_MetadataHeader`: header is set with the correct encoding when metadata is present, and omitted when absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)