### PR TITLE
fix: override minimatch for ReDoS CVE (Aikido/Dependabot)

### DIFF
--- a/ui/cropper/cropperjs/package.json
+++ b/ui/cropper/cropperjs/package.json
@@ -28,7 +28,8 @@
   "pnpm": {
     "overrides": {
       "esbuild": "0.25.0",
-      "brace-expansion": "2.0.2"
+      "brace-expansion": "2.0.2",
+      "minimatch": "9.0.9"
     }
   }
 }

--- a/ui/cropper/cropperjs/pnpm-lock.yaml
+++ b/ui/cropper/cropperjs/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   esbuild: 0.25.0
   brace-expansion: 2.0.2
+  minimatch: 9.0.9
 
 importers:
 
@@ -777,8 +778,8 @@ packages:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
     engines: {node: '>= 0.10.0'}
 
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   mitt@3.0.1:
@@ -1529,7 +1530,7 @@ snapshots:
       '@vue/compiler-vue2': 2.7.16
       '@vue/shared': 3.5.16
       alien-signals: 1.0.13
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       muggle-string: 0.4.1
       path-browserify: 1.0.1
     optionalDependencies:
@@ -1746,7 +1747,7 @@ snapshots:
 
   memorystream@0.3.1: {}
 
-  minimatch@9.0.5:
+  minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.0.2
 
@@ -1771,7 +1772,7 @@ snapshots:
       ansi-styles: 6.2.1
       cross-spawn: 7.0.6
       memorystream: 0.3.1
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       pidtree: 0.6.0
       read-package-json-fast: 3.0.2
       shell-quote: 1.8.3


### PR DESCRIPTION
## Summary
- **cropperjs**: override transitive `minimatch` 9.0.5 → 9.0.9 (>= 9.0.7 required) via scoped `pnpm.overrides`. minimatch is pulled only by build tooling (`vue-tsc` → `@vue/language-core`, `npm-run-all2`); the runtime dist bundle is unaffected, so no rebuild needed.

## Aikido / Jira issues resolved
- **QOR5-2545** — qor5/x cropperjs minimatch (HIGH, ReDoS GHSA-7r86-cg39-jmmj)

## Not fixed here (needs review)
- **QOR5-2869** — qor5/x vuetifyxjs `vite` (`<= 6.4.1`). The flagged vite is the transitive **5.4.21 pinned by `vitepress` 1.6.4** (docs tooling, dev-only — not in the `go:embed` runtime bundle, which is why Aikido auto-ignored it). There is no patched 5.x release; vitepress 1.6.4 requires the vite 5.x API, and bumping the direct vite to 8.x breaks peer deps (`unplugin-fonts`/`vitest`/vuetify plugins cap at vite 7). Clearing it needs an ecosystem-wide migration (vitepress major upgrade) — a human decision, not a safe automated bump.

## Verification
- `pnpm install` clean; `pnpm why minimatch` shows only 9.0.9 remaining (no vulnerable 9.0.5).
- Lockfile consistent; dist bundle unchanged (build tooling only).

## Deployment note
Skill does not merge or touch `release-*` branches. Merging is per team policy.