### PR TITLE
feat(grpcx): include err.details in error observability

### DIFF
--- a/grpcx/error.go
+++ b/grpcx/error.go
@@ -51,6 +51,7 @@ func DefaultErrorUnaryServerInterceptor(notifier errornotifier.Notifier) grpc.Un
 		if span != nil {
 			span.AppendKVs(
 				"err.reason", st.Reason(),
+				"err.details", st.Details(),
 			)
 		}
 
@@ -60,8 +61,9 @@ func DefaultErrorUnaryServerInterceptor(notifier errornotifier.Notifier) grpc.Un
 				"full_method":    info.FullMethod,
 				"err.stacktrace": fmt.Sprintf("%+v", err),
 				"err.reason":     st.Reason(),
+				"err.details":    st.Details(),
 			})
-			slog.ErrorContext(ctx, fmt.Sprintf("grpc err in %s: %+v", info.FullMethod, err), "full_method", info.FullMethod, "err.reason", st.Reason())
+			slog.ErrorContext(ctx, fmt.Sprintf("grpc err in %s: %+v", info.FullMethod, err), "full_method", info.FullMethod, "err.reason", st.Reason(), "err.details", st.Details())
 		}
 
 		return err

--- a/grpcx/error.go
+++ b/grpcx/error.go
@@ -46,12 +46,14 @@ func ErrorUnaryServerInterceptor(errHandler func(ctx context.Context, req any, i
 func DefaultErrorUnaryServerInterceptor(notifier errornotifier.Notifier) grpc.UnaryServerInterceptor {
 	return ErrorUnaryServerInterceptor(func(ctx context.Context, req any, info *grpc.UnaryServerInfo, err error) error {
 		st := statusx.Convert(err)
+		reason := st.Reason()
+		details := st.Details()
 
 		span := logtracing.SpanFromContext(ctx)
 		if span != nil {
 			span.AppendKVs(
-				"err.reason", st.Reason(),
-				"err.details", st.Details(),
+				"err.reason", reason,
+				"err.details", details,
 			)
 		}
 
@@ -60,10 +62,10 @@ func DefaultErrorUnaryServerInterceptor(notifier errornotifier.Notifier) grpc.Un
 			notifier.Notify(err, nil, map[string]any{
 				"full_method":    info.FullMethod,
 				"err.stacktrace": fmt.Sprintf("%+v", err),
-				"err.reason":     st.Reason(),
-				"err.details":    st.Details(),
+				"err.reason":     reason,
+				"err.details":    details,
 			})
-			slog.ErrorContext(ctx, fmt.Sprintf("grpc err in %s: %+v", info.FullMethod, err), "full_method", info.FullMethod, "err.reason", st.Reason(), "err.details", st.Details())
+			slog.ErrorContext(ctx, fmt.Sprintf("grpc err in %s: %+v", info.FullMethod, err), "full_method", info.FullMethod, "err.reason", reason, "err.details", details)
 		}
 
 		return err

--- a/grpcx/error_test.go
+++ b/grpcx/error_test.go
@@ -3,11 +3,16 @@ package grpcx
 import (
 	"context"
 	"errors"
+	"net/http"
 	"sync/atomic"
 	"testing"
 
+	"github.com/qor5/x/v3/statusx"
 	"github.com/stretchr/testify/require"
+	"github.com/theplant/appkit/logtracing"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 )
 
 func TestErrorUnaryServerInterceptor_DedupWithinSameInstance(t *testing.T) {
@@ -106,4 +111,125 @@ func TestErrorUnaryServerInterceptor_ErrorCanBeTransformed(t *testing.T) {
 
 	_, err := interceptor(context.Background(), nil, info, handler)
 	require.ErrorIs(t, err, transformedErr)
+}
+
+// fakeNotifier records the arguments of the most recent Notify call so tests
+// can assert on what DefaultErrorUnaryServerInterceptor reports.
+type fakeNotifier struct {
+	calls int
+	err   any
+	extra map[string]any
+}
+
+func (n *fakeNotifier) Notify(err any, _ *http.Request, extra map[string]any) {
+	n.calls++
+	n.err = err
+	n.extra = extra
+}
+
+// captureExporter records every span exported while it is registered.
+type captureExporter struct {
+	spans []*logtracing.SpanData
+}
+
+func (e *captureExporter) ExportSpan(sd *logtracing.SpanData) {
+	e.spans = append(e.spans, sd)
+}
+
+// findErrorInfo returns the ErrorInfo carried in a status' details, mirroring
+// how statusx.FromError reads it back.
+func findErrorInfo(details []any) *errdetails.ErrorInfo {
+	for _, d := range details {
+		if ei, ok := d.(*errdetails.ErrorInfo); ok {
+			return ei
+		}
+	}
+	return nil
+}
+
+// kvMap folds a logtracing keyvals slice into a map for easy assertions.
+func kvMap(keyvals []any) map[string]any {
+	m := map[string]any{}
+	for i := 0; i+1 < len(keyvals); i += 2 {
+		if k, ok := keyvals[i].(string); ok {
+			m[k] = keyvals[i+1]
+		}
+	}
+	return m
+}
+
+func TestDefaultErrorUnaryServerInterceptor_NotifiesInternalWithReasonAndDetails(t *testing.T) {
+	notifier := &fakeNotifier{}
+	interceptor := DefaultErrorUnaryServerInterceptor(notifier)
+
+	md := map[string]string{"tenant": "acme", "trace_id": "abc123"}
+	statusErr := statusx.New(codes.Internal, "INTERNAL_BOOM", "boom").WithMetadata(md).Err()
+
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	handler := func(ctx context.Context, req any) (any, error) {
+		return nil, statusErr
+	}
+
+	_, err := interceptor(context.Background(), nil, info, handler)
+	require.ErrorIs(t, err, statusErr)
+
+	require.Equal(t, 1, notifier.calls, "notifier should be called once for Internal errors")
+	require.Equal(t, "INTERNAL_BOOM", notifier.extra["err.reason"])
+
+	details, ok := notifier.extra["err.details"].([]any)
+	require.True(t, ok, "err.details should be reported as []any")
+	require.NotEmpty(t, details, "an Internal error should carry status details")
+
+	errorInfo := findErrorInfo(details)
+	require.NotNil(t, errorInfo, "status details should carry an ErrorInfo")
+	require.Equal(t, "INTERNAL_BOOM", errorInfo.GetReason())
+	require.Equal(t, md, errorInfo.GetMetadata())
+}
+
+func TestDefaultErrorUnaryServerInterceptor_DoesNotNotifyNonInternal(t *testing.T) {
+	notifier := &fakeNotifier{}
+	interceptor := DefaultErrorUnaryServerInterceptor(notifier)
+
+	statusErr := statusx.New(codes.InvalidArgument, "INVALID_ARGUMENT", "bad").Err()
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	handler := func(ctx context.Context, req any) (any, error) {
+		return nil, statusErr
+	}
+
+	_, err := interceptor(context.Background(), nil, info, handler)
+	require.ErrorIs(t, err, statusErr)
+	require.Equal(t, 0, notifier.calls, "notifier should not be called for non-Internal/Unknown errors")
+}
+
+func TestDefaultErrorUnaryServerInterceptor_AppendsReasonAndDetailsToSpan(t *testing.T) {
+	exporter := &captureExporter{}
+	logtracing.RegisterExporter(exporter)
+	defer logtracing.UnregisterExporter(exporter)
+
+	// The span KVs are appended regardless of the gRPC code, so use a
+	// non-Internal error to keep this test independent of the notifier path.
+	interceptor := DefaultErrorUnaryServerInterceptor(&fakeNotifier{})
+
+	md := map[string]string{"trace_id": "abc123"}
+	statusErr := statusx.New(codes.InvalidArgument, "INVALID_ARGUMENT", "bad").WithMetadata(md).Err()
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	handler := func(ctx context.Context, req any) (any, error) {
+		return nil, statusErr
+	}
+
+	ctx, _ := logtracing.StartSpan(context.Background(), "test", logtracing.WithSampler(logtracing.AlwaysSample()))
+	_, err := interceptor(ctx, nil, info, handler)
+	require.ErrorIs(t, err, statusErr)
+	logtracing.EndSpan(ctx, err)
+
+	require.Len(t, exporter.spans, 1)
+	kvs := kvMap(exporter.spans[0].Keyvals)
+
+	require.Equal(t, "INVALID_ARGUMENT", kvs["err.reason"])
+	details, ok := kvs["err.details"].([]any)
+	require.True(t, ok, "err.details should be appended to the span as []any")
+
+	errorInfo := findErrorInfo(details)
+	require.NotNil(t, errorInfo, "span details should carry an ErrorInfo")
+	require.Equal(t, md, errorInfo.GetMetadata())
 }


### PR DESCRIPTION
## What

`DefaultErrorUnaryServerInterceptor` already surfaces `err.reason` on the tracing span, the error notifier context, and the slog record. This also attaches `st.Details()` — the status' structured details (e.g. the `ErrorInfo` carrying metadata set via `statusx.WithMetadata`) — to all three sinks, so the extra context an error carries is visible when debugging `Unknown`/`Internal` failures.

```go
span.AppendKVs("err.reason", st.Reason(), "err.details", st.Details())
notifier.Notify(err, nil, map[string]any{..., "err.details": st.Details()})
slog.ErrorContext(ctx, ..., "err.details", st.Details())
```

## Tests

Adds coverage for the previously-untested `DefaultErrorUnaryServerInterceptor`:

- **`_NotifiesInternalWithReasonAndDetails`** — for an `Internal` error the notifier is called once and its extra context carries `err.reason` plus `err.details` (verified down to the `ErrorInfo` reason + metadata).
- **`_DoesNotNotifyNonInternal`** — a non-`Internal`/`Unknown` code (`InvalidArgument`) does not trigger the notifier.
- **`_AppendsReasonAndDetailsToSpan`** — `err.reason` and `err.details` are appended to the span regardless of the gRPC code, verified via a registered `logtracing` exporter.

`go test ./grpcx/` and `go vet ./grpcx/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)