### PR TITLE
ci: drop persisted Git credentials in actions/checkout (Aikido)

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: set Node.js environment
         uses: actions/setup-node@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,6 +27,8 @@ jobs:
           timezoneLinux: 'Asia/Shanghai'
 
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/.github/workflows/vuetifyjs-build.yml
+++ b/.github/workflows/vuetifyjs-build.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Fetches the entire history for a correct commit
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -50,9 +51,14 @@ jobs:
           # Check if there are any changes
           if ! git diff --cached --quiet; then
             git commit -m 'Add build artifacts'
-            git push origin HEAD:${{ github.head_ref }}
+            # Authenticate the push explicitly: checkout no longer persists the
+            # token in .git/config, and HEAD_REF goes through the environment so
+            # a crafted branch name cannot inject shell.
+            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" "HEAD:${HEAD_REF}"
           else
             echo "No changes detected; skipping commit."
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.head_ref }}
+          REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/vuetifyjs-test.yml
+++ b/.github/workflows/vuetifyjs-test.yml
@@ -35,6 +35,8 @@ jobs:
           timezoneLinux: 'Asia/Shanghai'
 
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
## Summary

Aikido flags `actions/checkout` for leaving the job token in `.git/config` (`http.extraheader`) after checkout, where any later step — including third-party actions — can read it. This repo accounts for 4 of the 10 sub-issues in that group.

Added `persist-credentials: false` to all four workflows.

**No-op for three of them** — they run no git operations after checkout:
- `go.yml` — `go build` / `go test`
- `vuetifyjs-test.yml` — `pnpm install` / `build` / `test:unit`
- `doc-build.yml` — `peaceiris/actions-gh-pages` authenticates via its own `github_token` input, not the ambient credential

**`vuetifyjs-build.yml` needed a real change.** It pushes the rebuilt `dist` bundle back to the PR branch, so the push is now authenticated explicitly through a token URL instead of relying on the credential checkout used to leave behind:

```diff
-  git push origin HEAD:${{ github.head_ref }}
+  git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" "HEAD:${HEAD_REF}"
```

While rewriting that line I also moved `github.head_ref` into the environment. Interpolating `${{ github.head_ref }}` straight into a `run:` block is a script-injection vector — a branch name containing shell metacharacters executes in the job. Passing it via `env:` makes it inert data.

## Aikido Issues Resolved

Group [33607621](https://app.aikido.dev/issues/33607621/detail?status=open) — 4 sub-issues in this repo:

- [374028910](https://app.aikido.dev/issues/33607621/detail?singleIssueFilter=374028910&status=open)
- [374028914](https://app.aikido.dev/issues/33607621/detail?singleIssueFilter=374028914&status=open)
- [374028917](https://app.aikido.dev/issues/33607621/detail?singleIssueFilter=374028917&status=open)
- [374028920](https://app.aikido.dev/issues/33607621/detail?singleIssueFilter=374028920&status=open)

## Verification

- All four workflow files parse as valid YAML
- No source changes — `dist/` is untouched, so no bundle rebuild is needed here
- The `vuetifyjs-build` push path is only exercised when the built `dist` actually differs; reviewers wanting to confirm it should watch the first PR after merge that changes `ui/vuetifyx/vuetifyxjs` sources

## Note

Branch is `fix/aikido-persist-credentials-2026-07-27` rather than the usual dated name — `fix/aikido-dependency-vulnerabilities-2026-07-27` is already taken by #621.