### PR TITLE
ci: stop actions/checkout persisting the GITHUB_TOKEN (Aikido)

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: set Node.js environment
         uses: actions/setup-node@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,6 +27,8 @@ jobs:
           timezoneLinux: 'Asia/Shanghai'
 
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/.github/workflows/vuetifyjs-build.yml
+++ b/.github/workflows/vuetifyjs-build.yml
@@ -28,11 +28,6 @@ jobs:
       - name: Install pnpm
         run: npm install -g pnpm@10.16.1
 
-      - name: Configure git for private repository access
-        run: |
-          git config --global url."https://${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
-          git config --global url."https://${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
-
       - name: Build project
         run: |
           cd ui/vuetifyx/vuetifyxjs
@@ -42,6 +37,12 @@ jobs:
       - name: Commit build artifacts
         if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
+          # Checkout no longer persists the token, so authenticate through gh's
+          # credential helper: it records only a helper directive
+          # (`!gh auth git-credential`) in ~/.gitconfig and resolves GH_TOKEN
+          # from this environment when git asks, so no token is written to disk.
+          gh auth setup-git --hostname github.com
+
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
@@ -51,14 +52,12 @@ jobs:
           # Check if there are any changes
           if ! git diff --cached --quiet; then
             git commit -m 'Add build artifacts'
-            # Authenticate the push explicitly: checkout no longer persists the
-            # token in .git/config, and HEAD_REF goes through the environment so
-            # a crafted branch name cannot inject shell.
-            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" "HEAD:${HEAD_REF}"
+            # HEAD_REF goes through the environment so a crafted branch name
+            # cannot inject shell.
+            git push origin "HEAD:${HEAD_REF}"
           else
             echo "No changes detected; skipping commit."
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_REF: ${{ github.head_ref }}
-          REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/vuetifyjs-build.yml
+++ b/.github/workflows/vuetifyjs-build.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Fetches the entire history for a correct commit
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -50,9 +51,14 @@ jobs:
           # Check if there are any changes
           if ! git diff --cached --quiet; then
             git commit -m 'Add build artifacts'
-            git push origin HEAD:${{ github.head_ref }}
+            # Authenticate the push explicitly: checkout no longer persists the
+            # token in .git/config, and HEAD_REF goes through the environment so
+            # a crafted branch name cannot inject shell.
+            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" "HEAD:${HEAD_REF}"
           else
             echo "No changes detected; skipping commit."
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.head_ref }}
+          REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/vuetifyjs-test.yml
+++ b/.github/workflows/vuetifyjs-test.yml
@@ -45,10 +45,5 @@ jobs:
       - name: Install pnpm
         run: npm install -g pnpm@10.16.1
 
-      - name: Configure git for private repository access
-        run: |
-          git config --global url."https://${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
-          git config --global url."https://${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
-
       - name: Build and Test
         run: cd ./ui/vuetifyx/vuetifyxjs/ && pnpm install --frozen-lockfile && pnpm run build && pnpm run test:unit

--- a/.github/workflows/vuetifyjs-test.yml
+++ b/.github/workflows/vuetifyjs-test.yml
@@ -35,6 +35,8 @@ jobs:
           timezoneLinux: 'Asia/Shanghai'
 
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
## What

Adds `persist-credentials: false` to every `actions/checkout` step (the Aikido finding), then deals with the two consequences.

**1. `persist-credentials: false` on 4 checkouts** — `doc-build.yml`, `go.yml`, `vuetifyjs-build.yml`, `vuetifyjs-test.yml`. Three of them are pure no-ops: qor5/x is public, so anonymous reads are free, and none of those jobs does a git network operation after checkout (`doc-build.yml` pushes to gh-pages through an action that takes `github_token` explicitly, not via `.git/config`).

**2. `vuetifyjs-build.yml`'s push** now authenticates through gh's credential helper:

```diff
-            git push origin HEAD:${{ github.head_ref }}
+            git push origin "HEAD:${HEAD_REF}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.head_ref }}
```

with `gh auth setup-git --hostname github.com` at the top of the step. gh records only a helper directive (`!gh auth git-credential`) in `~/.gitconfig` and resolves `GH_TOKEN` from the step environment when git asks — no token is written to disk. `HEAD_REF` goes through `env:` so a crafted branch name cannot inject shell.

**3. Removes "Configure git for private repository access"** from `vuetifyjs-build.yml` and `vuetifyjs-test.yml`. It was dead code *and* a token leak.

## Why that step had to go

```yaml
git config --global url."https://${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
git config --global url."https://${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
```

**It never did anything.** The only non-registry dependency is `"vuetify-pro-tiptap": "github:qor5/vuetify-pro-tiptap"`, which `pnpm-lock.yaml` resolves to a `codeload.github.com/....tar.gz` — an HTTPS download by pnpm's fetcher, not a git operation, so `url.insteadOf` never applies. `qor5/vuetify-pro-tiptap` is public and that tarball fetches anonymously (verified: HTTP 200, 669 KB, no credentials). No dependency in the lockfile uses a `git+` protocol or an SSH-form URL, so the `git@github.com:` rewrite has no subject either.

**And it leaked the token.** `${{ secrets.GITHUB_TOKEN }}` is interpolated straight into `run:`; Actions substitutes expressions *before* writing the step script to disk, so the token landed in the temp script file — and then in `~/.gitconfig` in plaintext, under the widest possible prefix (`https://github.com/`), rewriting every github.com URL for the rest of the job.

**It also blocked the helper.** URL rewriting happens before git looks for credentials, so while those lines existed, `git push origin` got a URL that already carried credentials and no credential helper would ever have been consulted.

## Verification

| Claim | Evidence |
|---|---|
| The removed step was dead code | Run `31085357751`, `Build project`: `pnpm install --frozen-lockfile` → `+ vuetify-pro-tiptap 2.6.0`, step green, with the step deleted |
| `gh auth setup-git` works on the runner | Same run, `Commit build artifacts` step green (`run:` uses `bash -e`, so a failing first command fails the step) |
| gh-helper push actually pushes | theplant/ciam#386 — same swap, run `31066109141`/`31081737389`, `449910b..19e3518 main -> main` |

**Not covered by this PR's CI, stated plainly:**

- The push line itself did not execute here — `dist` was unchanged, so the run logged `No changes detected; skipping commit.` The mechanism is proven by ciam#386; this workflow's specific push line will first execute on a PR that changes `dist`.
- `vuetifyjs-test.yml` does not run on this PR at all: it triggers on `branches: [main]` and this PR targets `master`. Its removed step is byte-identical to the one in `vuetifyjs-build.yml` and its `pnpm install --frozen-lockfile` runs against the same lockfile in the same directory, so the build job's result carries over — but it is an inference, not a green check.

## Result

No `git remote set-url`, no token in any git config, and no `${{ secrets.* }}` interpolated into a `run:` block anywhere in `.github/workflows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)