### PR TITLE
feat(gormx): let ContainerConfig pass extra postgres server arguments

### DIFF
--- a/gormx/container.go
+++ b/gormx/container.go
@@ -34,12 +34,19 @@ func SetupContainer(ctx context.Context, lc *lifecycle.Lifecycle, conf *Containe
 //
 // HostPort binds the container's 5432/tcp to a specific host port when set.
 // Leave it empty to let Docker allocate a random available port.
+//
+// Args carries extra postgres server arguments for settings that cannot be
+// changed after the postmaster has started — max_connections is the one that
+// bites in practice. They are appended after the built-in "-c fsync=off", so a
+// caller can also override that default by repeating the flag: postgres takes
+// the last occurrence.
 type ContainerConfig struct {
-	Image        string `confx:"image" usage:"PostgreSQL image to use"`
-	Username     string `confx:"username" usage:"PostgreSQL username"`
-	Password     string `confx:"password" usage:"PostgreSQL password"`
-	DatabaseName string `confx:"databaseName" usage:"PostgreSQL database name"`
-	HostPort     string `confx:"hostPort" usage:"PostgreSQL host port"`
+	Image        string   `confx:"image" usage:"PostgreSQL image to use"`
+	Username     string   `confx:"username" usage:"PostgreSQL username"`
+	Password     string   `confx:"password" usage:"PostgreSQL password"`
+	DatabaseName string   `confx:"databaseName" usage:"PostgreSQL database name"`
+	HostPort     string   `confx:"hostPort" usage:"PostgreSQL host port"`
+	Args         []string `confx:"args" usage:"Extra postgres server arguments, e.g. [\"-c\", \"max_connections=300\"]"`
 }
 
 // DefaultContainerConfig is the default configuration for starting a PostgreSQL test container.
@@ -88,7 +95,7 @@ func OpenContainer(ctx context.Context, conf *ContainerConfig) (_ *Container, xe
 			"POSTGRES_PASSWORD": conf.Password,
 			"POSTGRES_DB":       conf.DatabaseName,
 		},
-		Cmd:        []string{"postgres", "-c", "fsync=off"},
+		Cmd:        append([]string{"postgres", "-c", "fsync=off"}, conf.Args...),
 		WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
 	}
 	if conf.HostPort != "" {

--- a/gormx/container_test.go
+++ b/gormx/container_test.go
@@ -1,0 +1,38 @@
+package gormx_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/qor5/x/v3/gormx"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// TestOpenContainer_Args pins both halves of the contract: the caller's
+// arguments reach the postmaster, and they are appended to the built-in
+// "-c fsync=off" rather than replacing it.
+func TestOpenContainer_Args(t *testing.T) {
+	ctx := context.Background()
+
+	conf := gormx.DefaultContainerConfig()
+	conf.Args = []string{"-c", "max_connections=123"}
+
+	container, err := gormx.OpenContainer(ctx, conf)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = container.Terminate(context.WithoutCancel(ctx))
+	})
+
+	db, err := gorm.Open(postgres.Open(container.DSN), &gorm.Config{})
+	require.NoError(t, err)
+
+	var maxConnections string
+	require.NoError(t, db.Raw("SHOW max_connections").Scan(&maxConnections).Error)
+	require.Equal(t, "123", maxConnections)
+
+	var fsync string
+	require.NoError(t, db.Raw("SHOW fsync").Scan(&fsync).Error)
+	require.Equal(t, "off", fsync, "Args must append to the default arguments, not replace them")
+}


### PR DESCRIPTION
## 问题

`OpenContainer` 把 `Cmd` 写死：

```go
Cmd: []string{"postgres", "-c", "fsync=off"},
```

而 `ContainerConfig` 只暴露 `Image` / `Username` / `Password` / `DatabaseName` / `HostPort`。**只要调用方需要一个 postmaster 启动后就改不了的设置，这里就没有出口** —— `max_connections` 是实践中最先撞上的那个。

## 谁撞上了

`theplant/iam` 的测试提速（[theplant/iam#167](https://github.com/theplant/iam/pull/167)）：它把 38 个「每个 suite 一个 Postgres 容器」收敛成一个共享实例，各 suite 改用 `CREATE DATABASE ... TEMPLATE` 秒取独立库。收益很大（根包 265.658s → ~52s），但副作用是**所有 suite 的连接池现在压在同一个实例上**，于是 `max_connections=100` 成了「这个包能开多大并行」的天花板。

而且它是悬崖不是斜坡：

| | |
|---|---|
| `-parallel 8` | 过 |
| `-parallel 16` | `FATAL: sorry, too many clients already` (SQLSTATE 53300) |

因为没法通过 `ContainerConfig` 表达，那个仓库只能**放弃调用 `OpenContainer`，把整个 `ContainerRequest` 重新手写一遍**，就为了改 `Cmd` 里的一项——镜像和凭据还得继续从 `DefaultContainerConfig()` 读回来，免得和这里漂移。那 15 行重复代码就是这个 PR 想消灭的东西。

## 改动

```go
type ContainerConfig struct {
    ...
    Args []string `confx:"args" usage:"Extra postgres server arguments, e.g. [\"-c\", \"max_connections=300\"]"`
}

Cmd: append([]string{"postgres", "-c", "fsync=off"}, conf.Args...),
```

**追加而非替换**，所以：

- 内置的 `-c fsync=off` 不会被调用方无意中弄丢；
- 真想覆盖它的调用方可以重复该 flag —— postgres 取最后一次出现的值；
- 零值完全等于今天的行为，**对现有调用方是纯增量**，无需任何改动。

## 测试

新增 `gormx/container_test.go`，一个测试钉住契约的两半：

```go
conf.Args = []string{"-c", "max_connections=123"}
...
SHOW max_connections  ->  "123"   // 参数确实到了 postmaster
SHOW fsync            ->  "off"   // 且是追加，没把默认参数顶掉
```

`go test ./gormx/...` 全绿（`gormx` 16.9s、`gormx/postgresx` 8.4s）。

## 不在本 PR 范围内

`OpenContainer` 每次调用都起一个全新容器、零复用，这才是 iam 撞得最狠的根本原因（38 个 suite = 38 个容器 = ~152s 纯启动开销）。把「一个容器 + template database 池化」上提成 `gormx.TemplatePool` / `Fork(t)` 是更大的一步，等 iam 那边的收益跑稳了再单独提。

真要做的时候有两条经验值得直接带过来，两条都是实测踩出来的：

1. **fork 出的库必须 drop**。把 38 个库留在同一个实例里，会让越靠后的 suite 越慢——autovacuum launcher 会轮询每一个存在的库。iam 实测：不 drop 时最后 1/3 的 suite 慢约 1.8 倍（`TestSAMLConfig` 27.56s → 49.71s），整个改造的收益从 190s 掉到 38s。
2. **`max_connections` 要按预期并行度设**，也就是本 PR 这件事。

一个只有 `Fork` 而没有这两样的 `TemplatePool`，会在每个消费方原样复现这两个坑。