### PR TITLE
feat(gormx): add TemplatePool — one container, one migration, a private database per test

### DIFF
--- a/gormx/template_pool.go
+++ b/gormx/template_pool.go
@@ -1,0 +1,267 @@
+package gormx
+
+import (
+	"cmp"
+	"context"
+	stderrors "errors"
+	"fmt"
+	"io"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/pkg/errors"
+	"gorm.io/gorm"
+)
+
+// templateDatabaseName is the database every Fork clones. It is migrated once,
+// then left with zero open connections — PostgreSQL refuses to clone a database
+// that any session is still connected to.
+const templateDatabaseName = "gormx_template"
+
+// forkMaxIdleConns overrides DefaultDatabaseConfig's 20. That default is tuned
+// for a long-lived service holding one database; a fork is one test's private
+// database, and 20 idle connections per fork times N concurrent forks is both
+// wasted and the fastest way back to "too many clients already".
+const forkMaxIdleConns = 2
+
+// templatePoolMaxConnections is prepended to the container's arguments, ahead of
+// any the caller passed, so a caller who names max_connections themselves still
+// wins (postgres takes the last occurrence). The stock 100 is not a sensible
+// default for this type: a pool exists precisely to hand out many databases at
+// once, each with its own connection pool.
+const templatePoolMaxConnections = 300
+
+// TemplateMigrator prepares the template's schema. It receives both a live
+// connection to the template database and that database's DSN — use whichever
+// the migration tool needs: an external migrator (Atlas, golang-migrate) takes
+// the DSN, AutoMigrate and seed code take the *gorm.DB.
+//
+// The pool owns the connection and closes it as soon as the migrator returns, so
+// the migrator must not retain the *gorm.DB or leave a connection of its own
+// open against that DSN. Cloning the template fails outright while any session
+// is connected to it, so a leak here surfaces as
+// `source database "gormx_template" is being accessed by other users` on the
+// first Fork rather than as silent corruption.
+//
+// The context is the test binary's, not any one test's: the template outlives
+// whichever test happened to trigger the migration.
+type TemplateMigrator func(ctx context.Context, db *gorm.DB, dsn string) error
+
+// TemplatePool starts one PostgreSQL container, migrates one template database
+// inside it, and hands each test a private clone of that template.
+//
+// It exists because OpenContainer has no reuse: a package with N suites that
+// each call it pays N container starts plus N migration runs, which is linear
+// and dominated entirely by container startup (~3600ms against ~360ms for a
+// full migration in the case that motivated this). Cloning a finished template
+// is a file-level copy — tens of milliseconds, and independent of how many
+// migrations produced the schema.
+//
+// Isolation is stronger than the alternative of sharing one database and
+// truncating between tests: each test gets its own database, so there is no
+// per-package list of tables to keep in sync and no way to forget one. Because
+// each test owns its database, tests using a pool are also free to call
+// t.Parallel() — Fork deliberately does not call it for them, since whether a
+// package's tests may run concurrently depends on the rest of their state
+// (t.Setenv panics in a parallel test, package-level fixtures may be shared),
+// which only that package can know.
+//
+// Declare one per test binary and let it start itself:
+//
+//	var pool = gormx.NewTemplatePool(nil, migrate)
+//
+//	func TestSomething(t *testing.T) {
+//		db := pool.Fork(t)
+//		...
+//	}
+type TemplatePool struct {
+	conf    *ContainerConfig
+	migrate TemplateMigrator
+
+	once        sync.Once
+	container   *Container
+	admin       *gorm.DB
+	adminCloser io.Closer
+	baseURL     *url.URL
+	startErr    error
+
+	seq atomic.Uint64
+}
+
+// NewTemplatePool describes a pool. Nothing runs until the first Fork, so this
+// is safe to call from a package-level variable: a package whose tests are all
+// filtered out never starts a container. A nil conf uses DefaultContainerConfig.
+//
+// It panics on a nil migrator rather than deferring the complaint to the first
+// Fork — without one the pool is just OpenContainer, and at package-variable
+// scope the mistake is worth finding before any test runs.
+func NewTemplatePool(conf *ContainerConfig, migrate TemplateMigrator) *TemplatePool {
+	if migrate == nil {
+		panic("gormx: NewTemplatePool requires a TemplateMigrator")
+	}
+	return &TemplatePool{conf: conf, migrate: migrate}
+}
+
+// Fork clones the template into a database of this test's own and returns a
+// connection to it. The database and the connection are both torn down when the
+// test finishes.
+//
+// The first call starts the container and migrates the template, so it pays for
+// both; every call after that is one CREATE DATABASE. Concurrent first calls are
+// serialised, and a startup failure is reported to every test that asks for a
+// database, not only the one that happened to be first.
+func (p *TemplatePool) Fork(t testing.TB, opts ...gorm.Option) *gorm.DB {
+	t.Helper()
+
+	p.once.Do(p.start)
+	if p.startErr != nil {
+		t.Fatalf("gormx: failed to start the template pool: %+v", p.startErr)
+	}
+
+	name := p.forkName(t)
+	if err := p.admin.WithContext(t.Context()).Exec(
+		`CREATE DATABASE ` + name + ` TEMPLATE ` + templateDatabaseName,
+	).Error; err != nil {
+		t.Fatalf("gormx: failed to fork the template into %s: %+v", name, err)
+	}
+	// Registered before the connection's cleanup so it runs after it (t.Cleanup
+	// is LIFO), and registered before Open so a failure there does not leak the
+	// database. FORCE terminates any session the test left behind — a lifecycle
+	// that was never stopped, a background worker — which is fine for a database
+	// that exists only for this test.
+	t.Cleanup(func() {
+		if err := p.admin.Exec(`DROP DATABASE ` + name + ` WITH (FORCE)`).Error; err != nil {
+			t.Errorf("gormx: failed to drop fork %s: %+v", name, err)
+		}
+	})
+
+	db, closer, err := p.open(t.Context(), p.dsn(name), opts...)
+	if err != nil {
+		t.Fatalf("gormx: failed to connect to fork %s: %+v", name, err)
+	}
+	t.Cleanup(func() {
+		if err := closer.Close(); err != nil {
+			t.Errorf("gormx: failed to close fork %s: %+v", name, err)
+		}
+	})
+	return db
+}
+
+// Close releases the admin connection and terminates the container. Forks clean
+// themselves up with their own test, so this only tears down what the pool
+// itself holds, and it is a no-op for a pool that never started.
+//
+// Calling it from TestMain stops the container promptly; skipping it is not a
+// leak either, since testcontainers' reaper removes the container when the test
+// binary exits.
+func (p *TemplatePool) Close(ctx context.Context) error {
+	var errs []error
+	if p.adminCloser != nil {
+		errs = append(errs, p.adminCloser.Close())
+		p.adminCloser = nil
+	}
+	if p.container != nil {
+		errs = append(errs, p.container.Terminate(ctx))
+		p.container = nil
+	}
+	return errors.WithStack(stderrors.Join(errs...))
+}
+
+// start runs under p.once. It records its failure rather than returning it, so
+// that Fork can report the same error to every test that needs a database.
+func (p *TemplatePool) start() {
+	ctx := context.Background()
+
+	// Copy rather than mutate: conf belongs to the caller, and
+	// DefaultContainerConfig hands out a fresh value they may hold on to.
+	conf := *cmp.Or(p.conf, DefaultContainerConfig())
+	conf.Args = append(
+		[]string{"-c", fmt.Sprintf("max_connections=%d", templatePoolMaxConnections)},
+		conf.Args...,
+	)
+
+	container, err := OpenContainer(ctx, &conf)
+	if err != nil {
+		p.startErr = err
+		return
+	}
+	p.container = container
+	defer func() {
+		if p.startErr != nil {
+			if err := p.Close(ctx); err != nil {
+				p.startErr = stderrors.Join(p.startErr, err)
+			}
+		}
+	}()
+
+	p.baseURL, err = url.Parse(container.DSN)
+	if err != nil {
+		p.startErr = errors.Wrap(err, "failed to parse container DSN")
+		return
+	}
+
+	// The admin connection outlives every fork: it is the session that issues
+	// CREATE/DROP DATABASE, so it must not be connected to any database being
+	// cloned or dropped. The container's default database is that neutral spot.
+	p.admin, p.adminCloser, err = p.open(ctx, container.DSN)
+	if err != nil {
+		p.startErr = errors.Wrap(err, "failed to connect to the container's default database")
+		return
+	}
+	if err := p.admin.WithContext(ctx).Exec(`CREATE DATABASE ` + templateDatabaseName).Error; err != nil {
+		p.startErr = errors.Wrap(err, "failed to create the template database")
+		return
+	}
+
+	templateDSN := p.dsn(templateDatabaseName)
+	template, templateCloser, err := p.open(ctx, templateDSN)
+	if err != nil {
+		p.startErr = errors.Wrap(err, "failed to connect to the template database")
+		return
+	}
+	migrateErr := p.migrate(ctx, template, templateDSN)
+	// Close unconditionally, and before reporting the migration error: a failed
+	// migration must not leave the template pinned open either.
+	closeErr := templateCloser.Close()
+	if migrateErr != nil {
+		p.startErr = errors.Wrap(migrateErr, "failed to migrate the template database")
+		return
+	}
+	if closeErr != nil {
+		p.startErr = errors.Wrap(closeErr, "failed to release the template database")
+	}
+}
+
+// open dials one of the container's databases with the package's own defaults,
+// so a fork behaves like any other gormx-managed connection (tracing, plugins)
+// rather than a bare gorm.Open.
+func (p *TemplatePool) open(ctx context.Context, dsn string, opts ...gorm.Option) (*gorm.DB, io.Closer, error) {
+	conf := DefaultDatabaseConfig()
+	conf.DSN = dsn
+	conf.MaxIdleConns = forkMaxIdleConns
+	return Open(ctx, conf, opts...)
+}
+
+func (p *TemplatePool) dsn(database string) string {
+	u := *p.baseURL
+	u.Path = "/" + database
+	return u.String()
+}
+
+var nonIdentifierRunes = regexp.MustCompile(`[^a-z0-9]+`)
+
+// forkName keeps the test's name in the database name so a container left
+// running after a failure can be inspected, and prefixes a counter to stay
+// unique across subtests that share a name.
+func (p *TemplatePool) forkName(t testing.TB) string {
+	name := nonIdentifierRunes.ReplaceAllString(strings.ToLower(t.Name()), "_")
+	// PostgreSQL truncates identifiers at 63 bytes; leave room for the prefix.
+	if len(name) > 40 {
+		name = name[:40]
+	}
+	return fmt.Sprintf("fork_%d_%s", p.seq.Add(1), name)
+}

--- a/gormx/template_pool_test.go
+++ b/gormx/template_pool_test.go
@@ -1,0 +1,105 @@
+package gormx_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/qor5/x/v3/gormx"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+type TemplatePoolWidget struct {
+	ID   string `gorm:"primaryKey"`
+	Name string
+}
+
+// seedWidget is the row the migrator writes into the template. Every fork must
+// see it without re-running the migration.
+const seedWidget = "seeded-in-template"
+
+func migrateWidgets(_ context.Context, db *gorm.DB, dsn string) error {
+	if dsn == "" {
+		return gorm.ErrInvalidDB
+	}
+	if err := db.AutoMigrate(&TemplatePoolWidget{}); err != nil {
+		return err
+	}
+	return db.Create(&TemplatePoolWidget{ID: seedWidget, Name: "template"}).Error
+}
+
+// Declared at package scope, exactly as a consumer would: nothing starts until
+// the first Fork.
+var widgetPool = gormx.NewTemplatePool(nil, migrateWidgets)
+
+func TestTemplatePool(t *testing.T) {
+	t.Cleanup(func() { require.NoError(t, widgetPool.Close(context.Background())) })
+
+	// Reaching a fork at all proves the migrator's connection was released:
+	// CREATE DATABASE ... TEMPLATE fails outright while any session is still
+	// connected to the source.
+	t.Run("fork inherits the migrated schema and seed", func(t *testing.T) {
+		db := widgetPool.Fork(t)
+
+		var got TemplatePoolWidget
+		require.NoError(t, db.Where("id = ?", seedWidget).First(&got).Error)
+		require.Equal(t, "template", got.Name)
+	})
+
+	t.Run("forks do not see each other's writes", func(t *testing.T) {
+		a, b := widgetPool.Fork(t), widgetPool.Fork(t)
+
+		require.NoError(t, a.Create(&TemplatePoolWidget{ID: "only-in-a", Name: "a"}).Error)
+
+		var count int64
+		require.NoError(t, b.Model(&TemplatePoolWidget{}).Where("id = ?", "only-in-a").Count(&count).Error)
+		require.Zero(t, count, "a write in one fork must not be visible in another")
+
+		// The seed is still there in both — isolation is not achieved by
+		// handing one of them an empty database.
+		require.NoError(t, b.Model(&TemplatePoolWidget{}).Where("id = ?", seedWidget).Count(&count).Error)
+		require.Equal(t, int64(1), count)
+	})
+
+	// Dropping is not cosmetic: databases left behind make every later fork's
+	// suite slower, because the autovacuum launcher round-robins over every
+	// database that exists. This runs after the subtests above, so their three
+	// forks must be gone and only this one may remain.
+	t.Run("finished forks are dropped", func(t *testing.T) {
+		db := widgetPool.Fork(t)
+
+		var live []string
+		require.NoError(t, db.Raw(
+			`SELECT datname FROM pg_database WHERE datname LIKE 'fork_%' ORDER BY datname`,
+		).Scan(&live).Error)
+		require.Len(t, live, 1, "only the current fork should still exist, found %v", live)
+	})
+
+	t.Run("max_connections is raised above the stock 100", func(t *testing.T) {
+		db := widgetPool.Fork(t)
+
+		var maxConnections string
+		require.NoError(t, db.Raw("SHOW max_connections").Scan(&maxConnections).Error)
+		require.Equal(t, "300", maxConnections)
+	})
+}
+
+// The pool raises max_connections because handing out many databases at once is
+// its whole purpose, but a caller who names the setting must still win.
+func TestTemplatePool_CallerArgsWin(t *testing.T) {
+	conf := gormx.DefaultContainerConfig()
+	conf.Args = []string{"-c", "max_connections=137"}
+
+	pool := gormx.NewTemplatePool(conf, migrateWidgets)
+	t.Cleanup(func() { require.NoError(t, pool.Close(context.Background())) })
+
+	var maxConnections string
+	require.NoError(t, pool.Fork(t).Raw("SHOW max_connections").Scan(&maxConnections).Error)
+	require.Equal(t, "137", maxConnections)
+}
+
+func TestNewTemplatePool_RequiresMigrator(t *testing.T) {
+	require.PanicsWithValue(t, "gormx: NewTemplatePool requires a TemplateMigrator", func() {
+		gormx.NewTemplatePool(nil, nil)
+	})
+}


### PR DESCRIPTION
## 问题

`OpenContainer` 零复用。一个包里有 N 个 suite、每个都调它，就要付 N 次容器启动 + N 次全量迁移。这是线性叠加，而且**成本几乎全在容器启动**——在 `theplant/iam` 实测：

| | |
|---|---|
| 容器启动 | **~3600ms** |
| 一次完整迁移（33 个文件 / 173 条 SQL） | 360ms（9%） |

所以任何「合并迁移」「预生成 schema.sql」的方向都只在打那 9%。iam 有 38 个 suite，就是 38 个 Postgres 容器、~152s 纯 setup。更糟的是容器跑完不会中途销毁，最后 **40 个同时驻留**，Docker 开始拒绝分配端口：

```
port "5432/tcp" not found
fail to get test container endpoint
```

## 做法

一个容器、一个模板库，每个测试拿一份克隆：

```go
var pool = gormx.NewTemplatePool(nil, migrate)

func TestSomething(t *testing.T) {
    db := pool.Fork(t)
}
```

`CREATE DATABASE ... TEMPLATE` 是**文件级复制**，拷的是迁移跑完之后的成品字节，所以耗时与迁移条数无关——本 PR 测试里每个 fork **0.02–0.06s**。

隔离性强于舰队里几个仓库在用的「共用一个库 + truncate」模式：每个测试拿到真正独立的库，不需要维护「本包该清哪几张表」的清单，也就没有漏掉一张表导致隐蔽串扰的可能。

## 第一次 Fork 之前什么都不发生

这是相比初版的主要改动。初版是 `StartTemplatePool(ctx, ...)`，要求从 `TestMain` 里显式启动——结果是**把同一段惰性初始化样板推给每个消费方**，iam 那边真就长这样：

```go
var (poolOnce sync.Once; pool *gormx.TemplatePool; poolErr error)
poolOnce.Do(func() { pool, poolErr = gormx.StartTemplatePool(...) })
require.NoError(t, poolErr)
```

这段该在库里写一次，而不是每个仓库抄一遍。收进来之后还顺带消掉了三样东西：

- 构造函数不再会失败，所以**没有 `Must-` 变体**、没有 error 要往上传；
- 启动失败由 `Fork` 报给**每一个**要数据库的测试，而不只是碰巧第一个跑的那个；
- 一个测试被 `-run` 全部过滤掉的包，**根本不会起容器**。

## 五个设计决定

这五条都不是设想，是先在 `theplant/iam` 手写一遍（[theplant/iam#167](https://github.com/theplant/iam/pull/167)）踩出来的。

### 1. `Fork` 自己负责 drop

**这条最容易漏，漏了最贵。** 把克隆库留在实例里，会让**越靠后**的测试越慢——autovacuum launcher 会轮询每一个存在的库。iam 实测最后 1/3 的 suite 慢约 1.8 倍：

| suite | 不 drop |
|---|---|
| `TestSAMLConfig` | 27.56s → **49.71s** |
| `TestAdminService` | 31.65s → **50.63s** |

整个优化的收益从 190s 掉到 38s，直到加上 drop 才兑现。所以它放在 `Fork` 里而不是留给调用方——正是为了让任何消费方都无法复现这个坑。用 `WITH (FORCE)` 是因为测试可能留下活动会话（没停的 lifecycle、后台 worker），而这个库本来就只属于那个测试。有测试断言跑完的 fork 确实消失了。

### 2. 迁移回调不持有连接

```go
type TemplateMigrator func(ctx context.Context, db *gorm.DB, dsn string) error
```

同时给 `*gorm.DB` 和 DSN，因为两种真实用法都存在：外部迁移器（Atlas、golang-migrate）吃 DSN，`AutoMigrate` 和播种代码吃 DB。**连接由 pool 持有，回调一返回就关掉。**

克隆时源库上不能有任何活动连接，所以如果把「记得关」的责任交给调用方，就是给每个消费方发一把同样的枪。关闭是无条件的——迁移失败也不能把模板钉住。

### 3. `max_connections` 抬到 300

对一个「同时发放很多库、每个库各带连接池」的类型，stock 的 100 不是合理默认值。iam 在 `-parallel 16` 上就是死在 `FATAL: sorry, too many clients already`（SQLSTATE 53300）。

它**前置**于调用方的 `Args`，所以调用方自己指定时仍然赢（postgres 取最后一次出现的值）——这条有测试覆盖。

另外 fork 会把 `DefaultDatabaseConfig` 的 `maxIdleConns` 从 20 降到 2：20 适合「长驻服务 + 一个库」，不适合「N 个并发的单测试库」，否则 16 个 fork 就是 320 条空闲连接，正好把刚抬上去的 300 又顶爆。

### 4. `Fork` **不**替调用方调 `t.Parallel()`

每测试独立库正是并行安全的前提，iam 靠它拿到约 13 倍墙钟收益。但一个包的测试能不能真的并发，取决于 pool 看不到的状态——`t.Setenv` 在并行测试里会 panic，包级 fixture 可能被共享。所以能力写在类型文档里，决定权留给调用方。

### 5. `Close` 是可选的

它让容器立刻停掉，对没启动过的 pool 是 no-op；不调也不算泄漏——testcontainers 的 reaper 会在测试二进制退出时清掉容器。

## fork 走本包的 `Open`

因此和任何 gormx 管理的连接一样带 tracing 和插件，而不是裸 `gorm.Open`。这不只是为了一致：**它让测试跑在生产真正拿到的那套栈上**。iam 切过去的当天就因此暴露出一个自己模型里的潜伏 bug —— `Service` 同时嵌了 `gormx.Model` 又重复声明 `CreatedAt`/`UpdatedAt`，导致 `SoftDeleteUpdatedAtPlugin` 在一条 `SET` 里写两次 `updated_at`。裸 `gorm.Open` 把它藏了很久。

## 其它

**`TestSuite` 未改动。** 它的 `ResetDB` 基于 `AutoMigrate`，对任何有真实迁移的仓库都是错的工具（漏 partial index、漏自定义 DEFAULT、漏 check constraint），但现有消费方——包括本包自己的 `gorm_test.go`——依赖它。

## 测试

`gormx/template_pool_test.go`，黑盒，pool 声明在包级变量上（就是消费方的真实写法）：

- fork 继承迁移后的 schema 和模板里播的种子行；
- 两个 fork 互不可见对方的写入，**且两者都还看得到种子行**（隔离不是靠发一个空库实现的）；
- 前面 subtest 的三个 fork 在后续 subtest 里已经消失（`pg_database WHERE datname LIKE 'fork_%'` 只剩当前这一个）；
- `SHOW max_connections` 默认 300，调用方指定 137 时为 137；
- 缺 migrator 时 panic。

能跑到 fork 这一步本身就证明了迁移回调的连接被释放了——否则第一次克隆就会因 `source database "gormx_template" is being accessed by other users` 直接失败。测试里也能看到惰性启动：第一个 subtest 1.10s（它付了容器启动的账），后面三个 0.02–0.06s。

`go test ./gormx/...` 全绿（`gormx` 5.3s、`gormx/postgresx` 2.2s）。

## 后续

`theplant/iam` 是第一个消费方，正在同步切换。`iam/saml` 是第二个天然目标（两个 suite 各起一个容器），走 `AutoMigrate` 那条路径。

Refs: QOR5-3381
